### PR TITLE
Bump logback.version from 1.2.8 to 1.2.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.checkstyle.plugin.version>3.1.2</maven.checkstyle.plugin.version>
         <slf4j.version>1.7.32</slf4j.version>
         <jd.version>1.1.3</jd.version>
-        <logback.version>1.2.8</logback.version>
+        <logback.version>1.2.9</logback.version>
         <jcommander.version>1.32</jcommander.version>
         <junit.version>4.13.2</junit.version>
     </properties>


### PR DESCRIPTION
Bumps `logback.version` from 1.2.8 to 1.2.9.

Updates `logback-core` from 1.2.8 to 1.2.9

Updates `logback-classic` from 1.2.8 to 1.2.9

---
updated-dependencies:
- dependency-name: ch.qos.logback:logback-core
  dependency-type: direct:development
  update-type: version-update:semver-patch
- dependency-name: ch.qos.logback:logback-classic
  dependency-type: direct:development
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>